### PR TITLE
read DNS ip address from openvpn out ( fix #3 )

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ documentation = "https://docs.rs/openaws-vpn-client/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+regex= "1"
 gtk = "=0.14.3"
 lazy_static = "=1.4.0"
 tokio = { version = "=1.14.0", features = ["full"] }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -165,6 +165,11 @@ pub async fn connect_ovpn(
         if let Ok(ref line) = next {
             if let Some(line) = line {
                 log.append_process(pid, line.as_str());
+                tokio::spawn(async move {
+                    // Process each socket concurrently.
+                    parse_dns(line.to_string())
+                        .and_then(|dns_address| _WIP_("Do something with this IP address"))
+                });
             } else {
                 break;
             }


### PR DESCRIPTION
fixes https://github.com/JonathanxD/openaws-vpn-client/issues/3

for now, this will read the "here's a DNS ip address you should set to", but I don't know exactly what to do with it. systemd-resolved requires an interface index... which I dunno where to get it from.