### PR TITLE
Add support for Mac OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "openaws-vpn-client"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "ctrlc",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["strip"]
 
 [package]
 name = "openaws-vpn-client"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 authors = ["KoresFramework", "Jonathan H. R. Lopes <jhrldev@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Then click on the **Connect** button.
 
 The regular connection flow will start, login into the AWS account. If the authentication succeeds, you will be redirected to a local address that loads the authentication credentials.
 
-After the credentials are loaded, the OpenVPN command will be executed, this requires root privileges, so `pkexec` is used to launch OpenVPN, which will prompt for your root password.
+After the credentials are loaded, the OpenVPN command will be executed. Launching OpenVPN requires root privileges, achieved through `pkexec` on Linux, or `sudo` on Mac. When launching OpenVPN, you will be prompted for your root password.
 
 ### Disconnecting
 
-Clicking on the **Disconnect** button or closing the GUI, will disconnect the VPN, it does require root privileges as well (and `pkexec` is used) to kill the OpenVPN process.
+Clicking on the **Disconnect** button or closing the GUI, will disconnect the VPN, it does require root privileges as well (and either `pkexec` or `sudo` is used) to kill the OpenVPN process.
 
 If the openaws-vpn-client crashes, the VPN connection will not be closed, but in the next time you open the GUI, you will be asked to kill old OpenVPN process.
 


### PR DESCRIPTION
This adds support for Mac OS by changing some OS-specific implementation details:

- Uses `sudo` instead of `pkexec` as this is not present on Mac OS (and `sudo` opens a password prompt on Mac OS)
- The `cmd` column for ps is named `command` on Mac
- Validates the output from `ps` before killing the OpenVPN process differently on Mac