### PR TITLE
Add `postInstall` phase to install patched `openvpn`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,10 @@
           src = ./.;
           buildInputs = [ pkg-config glib gtk3 ];
           nativeBuildInputs = [ pkg-config wrapGAppsHook makeWrapper ];
+
+          postInstall = ''
+            ln -s ${openvpn-patched}/bin/openvpn $out/bin/openvpn-patched
+          '';
         };
 
         overlays.default = final: prev: {


### PR DESCRIPTION
Hi again, here's a small fix for my previous PR, that makes the `openvpn` version available in the `$out/bin` directory.