### PR TITLE
Add xdg utils and openvpn patched

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,10 @@
           nativeBuildInputs = [ pkg-config wrapGAppsHook makeWrapper ];
 
           postInstall = ''
-            ln -s ${openvpn-patched}/bin/openvpn $out/bin/openvpn-patched
+            cp -r $src/share $out/share
+            wrapProgram "$out/bin/openaws-vpn-client" \
+              --set-default OPENVPN_FILE "${openvpn-patched}/bin/openvpn" \
+              --set-default SHARED_DIR "$out/share"
           '';
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
       in with pkgs; rec {
         defaultPackage = naersk'.buildPackage {
           src = ./.;
-          buildInputs = [ pkg-config glib gtk3 ];
+          buildInputs = [ pkg-config glib gtk3 xdg-utils ];
           nativeBuildInputs = [ pkg-config wrapGAppsHook makeWrapper ];
 
           postInstall = ''


### PR DESCRIPTION
Hey, another small quality of life PR:

- `xdg-utils` is a required runtime dependency, since `xdg-open` is being used to open the SAML link.
- Using `wrapProgram` to set defaults for the `OPENVPN_FILE` and `SHARED_DIR`.

All in all, it should now be possible to just run `openaws-vpn-client` after installing this.
